### PR TITLE
Jetfinding edge detection

### DIFF
--- a/resolutionJETS/resolutionJETStree.C
+++ b/resolutionJETS/resolutionJETStree.C
@@ -22,6 +22,7 @@ const int firstEtaBin[njettypes] = {1, 10, 10, 10, 10};
 const float min_eta[njettypes]   = {-3.5, 1.5, 1.5, 1.5, 1.5};  // TODO Save this info as metadata...
 const float max_eta[njettypes]   = {3.5, 3.5, 3.5, 3.5, 3.5};
 
+// Regions to group plots into
 const int eta_regions = 3;
 const float eta_regions_boundaries[eta_regions + 1] = {-3.5, -1.5, 1.5, 3.5};
 

--- a/treeAnalysis/jetresolutionhistos.cxx
+++ b/treeAnalysis/jetresolutionhistos.cxx
@@ -19,6 +19,11 @@ TString jettype[njettypes] = {"track", "full","hcal", "calo","all", "nocluster",
 const float min_eta[njettypes] = {-3.5, 0, 1.5, 1.5, 0, 1.5, 1.5};  // TODO Save this info as metadata...
 const float max_eta[njettypes] = {3.5, 0, 3.5, 3.5, 0, 3.5, 3.5};
 
+
+// Edges of detectors; prevent jet finding within R of boundaries
+const int detectors = 1;
+const float detector_eta_boundaries[detectors + 1] = {-3.5, 3.5};
+
 TH2F* h_jet_E_eta[njettypes] = {NULL};
 TH2F* h_MCjet_E_eta[njettypes] = {NULL};
 TH2F* h_jetscale_E[njettypes][nEta+1] = {NULL};
@@ -206,6 +211,11 @@ void jetresolutionhistos(std::tuple<std::shared_ptr<fastjet::ClusterSequenceArea
       Int_t et = 0;
       while ( ( std::get<1>(truejets)[j].eta() > partEta[et+1] ) && ( et < nEta )) et++;
       
+      for (std::size_t k = 0; k < detectors; k++) {   // Skip jets within R of the detector boundary
+        if (std::abs(std::get<1>(recjets)[i].eta() - detector_eta_boundaries[k]) < 0.5) {
+          continue;
+        }
+      }
       if(deltaRTrueRec<0.25){
         // Spectra
         h3D_truth_reco_phi[select]->Fill(std::get<1>(truejets)[j].phi(), std::get<1>(recjets)[i].phi(), eta);

--- a/treeAnalysis/jetresolutionhistos.cxx
+++ b/treeAnalysis/jetresolutionhistos.cxx
@@ -213,17 +213,18 @@ void jetresolutionhistos(std::tuple<std::shared_ptr<fastjet::ClusterSequenceArea
       if (eta < min_eta[select] || eta > max_eta[select]) {
         continue;
       }
-      Double_t deltaRTrueRec = std::get<1>(truejets)[j].delta_R(std::get<1>(recjets)[i]);
-      // cout << deltaRTrueRec << endl;
-      Int_t et = 0;
-      while ( ( std::get<1>(truejets)[j].eta() > partEta[et+1] ) && ( et < nEta )) et++;
-      
       for (std::size_t k = 0; k < detectors[select]; k++) {   // Skip jets within R of the detector boundary
         if (std::abs(std::get<1>(recjets)[i].eta() - detector_eta_boundaries[select][k]) < jetR) {
           // std::cout << "excluding jet near edge of " << jettype[select] << std::endl;
           continue;
         }
       }
+      
+      Double_t deltaRTrueRec = std::get<1>(truejets)[j].delta_R(std::get<1>(recjets)[i]);
+      // cout << deltaRTrueRec << endl;
+      Int_t et = 0;
+      while ( ( std::get<1>(truejets)[j].eta() > partEta[et+1] ) && ( et < nEta )) et++;
+      
       if(deltaRTrueRec<0.25){
         // Spectra
         h3D_truth_reco_phi[select]->Fill(std::get<1>(truejets)[j].phi(), std::get<1>(recjets)[i].phi(), eta);

--- a/treeAnalysis/jetresolutionhistos.cxx
+++ b/treeAnalysis/jetresolutionhistos.cxx
@@ -21,7 +21,7 @@ const float max_eta[njettypes] = {3.5, 0, 3.5, 3.5, 0, 3.5, 3.5};
 
 
 // Edges of detectors; prevent jet finding within R of boundaries
-const int max_detectors = 1;
+const int max_detector_sections = 1;
 const int detectors[njettypes] = {1, 0, 1, 1, 0, 1, 1};
 const float detector_eta_boundaries[njettypes][max_detectors + 1] = {{-3.5, 3.5},    // Tracking
                                                                     {},
@@ -185,7 +185,7 @@ void jetresolutionhistos(std::tuple<std::shared_ptr<fastjet::ClusterSequenceArea
         if (eta < min_eta[select] || eta > max_eta[select]) {
           continue;
         }
-        if (std::get<1>(truejets)[j].delta_R(std::get<1>(recjets)[i]) < 0.25) {
+        if (std::get<1>(truejets)[j].delta_R(std::get<1>(recjets)[i]) < 0.5) {
           h_matched_count[select]->Fill(std::get<1>(truejets)[j].E());
           matched++;
           break;

--- a/treeAnalysis/treeProcessing.C
+++ b/treeAnalysis/treeProcessing.C
@@ -846,13 +846,13 @@ void treeProcessing(
             fillJetSpectra(jetObservablesCalo, std::get<1>(jetsCaloRec), jetR);
             fillJetSpectra(jetObservablesFull, std::get<1>(jetsFullRec), jetR);
 
-            jetresolutionhistos(jetsTrackRec,jetsTrueCharged,0);
-            jetresolutionhistos(jetsFullRec,jetsTrue,1);
-            jetresolutionhistos(jetsHcalRec,jetsTrue,2);
-            jetresolutionhistos(jetsCaloRec,jetsTrue,3);
-            jetresolutionhistos(jetsAllRec,jetsTrue,4);
-            jetresolutionhistos(jetsNoCluster, jetsTrue, 5);
-            jetresolutionhistos(jetsEmcalRec, jetsTrue, 6);
+            jetresolutionhistos(jetsTrackRec, jetsTrueCharged, 0, jetR);
+            jetresolutionhistos(jetsFullRec, jetsTrue, 1, jetR);
+            jetresolutionhistos(jetsHcalRec, jetsTrue, 2, jetR);
+            jetresolutionhistos(jetsCaloRec, jetsTrue, 3, jetR);
+            jetresolutionhistos(jetsAllRec, jetsTrue, 4, jetR);
+            jetresolutionhistos(jetsNoCluster,  jetsTrue,  5, jetR);
+            jetresolutionhistos(jetsEmcalRec,  jetsTrue,  6, jetR);
             
 // TString jettype[njettypes] = {"track", "full","hcal","calo","all"};
         }


### PR DESCRIPTION
Support to exclude jets reconstructed within R of the edge of the detector's acceptance.

Currently only estimates, need to get in touch with working groups and inquire what the most recent values are.

@raymondEhlers 